### PR TITLE
updated some poc env vars

### DIFF
--- a/reg/airpollution.json
+++ b/reg/airpollution.json
@@ -8,9 +8,7 @@
       "label": "app",
       "publishable": true,
       "mappings": {
-        "MTN_AIRPOLLUTION": "true",
         "HZN_AIRPOLLUTION": "true",
-        "MTN_PURPLE_AIR_SENSOR_NAME": "$AIRPOLLUTION_PURPLE_AIR_SENSOR_NAME",
         "HZN_PURPLE_AIR_SENSOR_NAME": "$AIRPOLLUTION_PURPLE_AIR_SENSOR_NAME"
       }
     },

--- a/reg/citygram.json
+++ b/reg/citygram.json
@@ -8,7 +8,6 @@
       "label": "app",
       "publishable": true,
       "mappings": {
-        "MTN_CITYGRAM": "true",
         "HZN_CITYGRAM": "true"
       }
     },

--- a/reg/pws.json
+++ b/reg/pws.json
@@ -11,7 +11,9 @@
         "HZN_PWS": "true",
         "HZN_WUGNAME": "$PWS_WUGNAME",
         "HZN_PWS_MODEL": "$PWS_MODEL",
-        "HZN_PWS_ST_TYPE": "$PWS_ST_TYPE"
+        "MTN_PWS_MODEL": "$PWS_MODEL",
+        "HZN_PWS_ST_TYPE": "$PWS_ST_TYPE",
+        "MTN_PWS_ST_TYPE": "$PWS_ST_TYPE"
       }
     },
     {


### PR DESCRIPTION
- Removed a few MTN_ env vars from airpollution.json and citygram.json (Note: the MTN_ env vars i left in citygram.json need to stay there for the foreseeable future because they are used by the firmware, which can't be updated right now.)
- Had to add 2 MTN_ env vars back into pws.json because i realized the pws firmware needs them and i didn't update that (it's more difficult to update).